### PR TITLE
Do not include file names in `NOTICE` and `OK` messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,7 @@ impl WebSocketService {
                         }
                     }
                     if !self.replied {
-                        let reply = NostrReply::Notice(format!("error: {}", e));
+                        let reply = NostrReply::Notice(format!("error: {}", e.inner));
                         self.websocket.send(Message::text(reply.as_json())).await?;
                     }
                     if self.error_punishment >= 1.0 {

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -273,7 +273,7 @@ impl WebSocketService {
         if !event_flags.author_is_an_authorized_user || GLOBALS.config.read().verify_events {
             // Verify the event is valid (id is hash, signature is valid)
             if let Err(e) = event.verify() {
-                return Err(ChorusError::EventIsInvalid(format!("{}", e)).into());
+                return Err(ChorusError::EventIsInvalid(format!("{}", e.inner)).into());
             }
         }
 


### PR DESCRIPTION
Error messages in `NOTICE` or `OK` messages contain debug information like this:

```
["NOTICE","error: JSON bad: Too Short or Missing Fields at position 1, /home/mado/.cargo/git/checkouts/pocket-59454be2808be695/2c90b6c/pocket-types/src/json/json_parse.rs:24:73, src/nostr.rs:23:9"]
```

It's not quite helpful for relay users, and I don't like exposing file names of my computer.