### PR TITLE
add live conns to management api + fixing header value.

### DIFF
--- a/src/web/management/mod.rs
+++ b/src/web/management/mod.rs
@@ -18,7 +18,7 @@ fn respond(
         .header("Access-Control-Allow-Origin", "*")
         .header("Access-Control-Allow-Headers", "*")
         .header("Access-Control-Allow-Methods", "*")
-        .header("Content-Type", "application/nostr+json")
+        .header("Content-Type", "application/nostr+json+rpc")
         .status(status)
         .body(
             Full::new(s.into_bytes().into())
@@ -105,7 +105,8 @@ pub fn handle_inner(command: Value) -> Result<Option<Value>, Error> {
                 "listallowedpubkeys",
                 "listbannedevents",
                 "listbannedpubkeys",
-                "supportedmethods"
+                "supportedmethods",
+                "liveconnections"
             ]
         }))),
 
@@ -213,6 +214,14 @@ pub fn handle_inner(command: Value) -> Result<Option<Value>, Error> {
         "changerelayname" => Err(ChorusError::NotImplemented.into()),
         "changerelaydescription" => Err(ChorusError::NotImplemented.into()),
         "changerelayicon" => Err(ChorusError::NotImplemented.into()),
+
+        // System
+        "liveconnections" => {
+            let num = &GLOBALS.num_connections;
+            Ok(Some(json!({
+                "result": num,
+            })))
+        }
 
         _ => Err(ChorusError::NotImplemented.into()),
     }


### PR DESCRIPTION
im developing a manament api which needs this info on main dashboard. like this:

![Screenshot from 2025-01-29 18-11-40](https://github.com/user-attachments/assets/57bcb1f4-2344-4c6e-a177-50b3c3776288)


im adding these apis since chorus supports nip-86.

i would add total events and other stuff as well soon. do you have plan to support them as well? so i wont open pointless prs. :saluting_face: 